### PR TITLE
Creating sensor observable with the ability to specify handler

### DIFF
--- a/library/src/main/java/com/github/pwittchen/reactivesensors/library/ReactiveSensors.java
+++ b/library/src/main/java/com/github/pwittchen/reactivesensors/library/ReactiveSensors.java
@@ -109,7 +109,8 @@ public final class ReactiveSensors {
    * @return RxJava Observable with ReactiveSensorEvent
    */
   public Observable<ReactiveSensorEvent> observeSensor(int sensorType,
-                                                       final int samplingPeriodInUs, final Handler handler) {
+                                                       final int samplingPeriodInUs,
+                                                       final Handler handler) {
 
     if (!hasSensor(sensorType)) {
       String format = "Sensor with id = %d is not available on this device";


### PR DESCRIPTION
Create another method of generating sensor stream observable, which includes the handler param, so that user can specify which handler the sensor events will be delivered to.